### PR TITLE
Added build only their own project

### DIFF
--- a/modules/task_1/ndanilov_rows_matrix_sum/CMakeLists.txt
+++ b/modules/task_1/ndanilov_rows_matrix_sum/CMakeLists.txt
@@ -3,6 +3,11 @@ project( ndanilov_rows_matrix_sum )
 message( STATUS "-- " ${PROJECT_NAME} )
 add_executable( ${PROJECT_NAME} main.cpp )
 
+find_package( MPI REQUIRED )
+if( MPI_FOUND )
+    include_directories( ${MPI_INCLUDE_PATH} )
+endif( MPI_FOUND )
+
 if( MPI_COMPILE_FLAGS )
     set_target_properties( ${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "${MPI_COMPILE_FLAGS}" )
 endif( MPI_COMPILE_FLAGS )

--- a/modules/task_1/ndanilov_rows_matrix_sum/CMakeLists.txt
+++ b/modules/task_1/ndanilov_rows_matrix_sum/CMakeLists.txt
@@ -1,3 +1,5 @@
+cmake_minimum_required( VERSION 2.8 )
+
 project( ndanilov_rows_matrix_sum )
 
 message( STATUS "-- " ${PROJECT_NAME} )


### PR DESCRIPTION
**It was impossible to build only your project, because cmake determined the dependencies in the root directories.**

### **Default build from root directory with cmake update**

```
➜ MPI_Practical_Course dev_nd_cmake_update cmake .
-- The C compiler identification is GNU 4.8.5
-- The CXX compiler identification is GNU 4.8.5
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features-- Detecting CXX compile features - done
-- MPI_Practical_Course
-- Found MPI_C: /usr/lib/x86_64-linux-gnu/libmpich.so (found version "3.1")
-- Found MPI_CXX: /usr/lib/x86_64-linux-gnu/libmpichcxx.so (found version "3.1")
-- Found MPI: TRUE (found version "3.1")
-- -- test_task
-- Task 1
-- -- Perov_Dima_task1_SumElVect
-- -- vikhrev_array_sum
-- -- Yakovlev_Pavel_mul_vect
-- -- Vdovin_Eugene_task1_NumWords
-- -- Repin_Vladimir_Wrong_Order_Count
-- -- Gaidaichuk_Yuri_task1_Arrays_Matching
-- -- Druzhinin_Alexei_task1_MinElVect
-- -- Zolotareva_Olesya_task1_MiddleValueVect
-- -- ndanilov_rows_matrix_sum
-- Task 2
-- Task 3
-- Configuring done
-- Generating done
-- Build files have been written to: /home/xubuntu/MPI_Practical_Course
➜ MPI_Practical_Course dev_nd_cmake_update make
Scanning dependencies of target test_task
[  5%] Building CXX object modules/test_task/CMakeFiles/test_task.dir/main.cpp.o
[ 10%] Linking CXX executable test_task
[ 10%] Built target test_task
Scanning dependencies of target Perov_Dima_task1_SumElVect
[ 15%] Building CXX object modules/task_1/Perov_Dima_task1_SumElVect/CMakeFiles/Perov_Dima_task1_SumElVect.dir/main.cpp.o
[ 20%] Linking CXX executable Perov_Dima_task1_SumElVect
[ 20%] Built target Perov_Dima_task1_SumElVect
Scanning dependencies of target vikhrev_array_sum
[ 25%] Building CXX object modules/task_1/vikhrev_array_sum/CMakeFiles/vikhrev_array_sum.dir/array_sum.cpp.o
[ 30%] Linking CXX executable vikhrev_array_sum
[ 30%] Built target vikhrev_array_sum
Scanning dependencies of target Yakovlev_Pavel_mul_vect
[ 35%] Building CXX object modules/task_1/Yakovlev_Pavel_mul_vect/CMakeFiles/Yakovlev_Pavel_mul_vect.dir/main.cpp.o
[ 40%] Linking CXX executable Yakovlev_Pavel_mul_vect
[ 40%] Built target Yakovlev_Pavel_mul_vect
Scanning dependencies of target Vdovin_Eugene_task1_NumWords
[ 45%] Building CXX object modules/task_1/Vdovin_Eugene_task1_NumWords/CMakeFiles/Vdovin_Eugene_task1_NumWords.dir/main.cpp.o
[ 50%] Linking CXX executable Vdovin_Eugene_task1_NumWords
[ 50%] Built target Vdovin_Eugene_task1_NumWords
Scanning dependencies of target Repin_Vladimir_Wrong_Order_Count
[ 55%] Building CXX object modules/task_1/Repin_Vladimir_Wrong_Order_Count/CMakeFiles/Repin_Vladimir_Wrong_Order_Count.dir/main.cpp.o
[ 60%] Linking CXX executable Repin_Vladimir_Wrong_Order_Count
[ 60%] Built target Repin_Vladimir_Wrong_Order_Count
Scanning dependencies of target Gaidaichuk_Yuri_task1_Arrays_Matching
[ 65%] Building CXX object modules/task_1/Gaidaichuk_Yuri_task1_Arrays_Matching/CMakeFiles/Gaidaichuk_Yuri_task1_Arrays_Matching.dir/main.cpp.o
[ 70%] Linking CXX executable Gaidaichuk_Yuri_task1_Arrays_Matching
[ 70%] Built target Gaidaichuk_Yuri_task1_Arrays_Matching
Scanning dependencies of target Druzhinin_Alexei_task1_MinElVect
[ 75%] Building CXX object modules/task_1/Druzhinin_Alexei_task1_MinElVect/CMakeFiles/Druzhinin_Alexei_task1_MinElVect.dir/main.cpp.o
[ 80%] Linking CXX executable Druzhinin_Alexei_task1_MinElVect
[ 80%] Built target Druzhinin_Alexei_task1_MinElVect
Scanning dependencies of target Zolotareva_Olesya_task1_MiddleValueVect
[ 85%] Building CXX object modules/task_1/Zolotareva_Olesya_task1_MiddleValueVect/CMakeFiles/Zolotareva_Olesya_task1_MiddleValueVect.dir/main.cpp.o
[ 90%] Linking CXX executable Zolotareva_Olesya_task1_MiddleValueVect
[ 90%] Built target Zolotareva_Olesya_task1_MiddleValueVect
Scanning dependencies of target ndanilov_rows_matrix_sum
[ 95%] Building CXX object modules/task_1/ndanilov_rows_matrix_sum/CMakeFiles/ndanilov_rows_matrix_sum.dir/main.cpp.o
[100%] Linking CXX executable ndanilov_rows_matrix_sum
[100%] Built target ndanilov_rows_matrix_sum
➜ MPI_Practical_Course dev_nd_cmake_update mpirun -np 4 modules/task_1/ndanilov_rows_matrix_sum/ndanilov_rows_matrix_sum 10 10

Sequential Time = 7.15256e-07
Sequential Sum Vector:
267 525 554 562 501 495 476 358 491 506

Parallel Time = 1.74046e-05
Parallel Sum Vector:
267 525 554 562 501 495 476 358 491 506
➜ MPI_Practical_Course dev_nd_cmake_update
```


### **Build from their own directory with cmake update**

```
➜ ndanilov_rows_matrix_sum dev_nd_cmake_update cmake .
-- The C compiler identification is GNU 4.8.5
-- The CXX compiler identification is GNU 4.8.5
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- -- ndanilov_rows_matrix_sum
-- Found MPI_C: /usr/lib/x86_64-linux-gnu/libmpich.so (found version "3.1")
-- Found MPI_CXX: /usr/lib/x86_64-linux-gnu/libmpichcxx.so (found version "3.1")
-- Found MPI: TRUE (found version "3.1")
-- Configuring done
-- Generating done
-- Build files have been written to: /home/xubuntu/MPI_Practical_Course/modules/task_1/ndanilov_rows_matrix_sum
➜ ndanilov_rows_matrix_sum dev_nd_cmake_update make
Scanning dependencies of target ndanilov_rows_matrix_sum
[ 50%] Building CXX object CMakeFiles/ndanilov_rows_matrix_sum.dir/main.cpp.o
[100%] Linking CXX executable ndanilov_rows_matrix_sum
[100%] Built target ndanilov_rows_matrix_sum
➜ ndanilov_rows_matrix_sum dev_nd_cmake_update mpirun -np 4 ./ndanilov_rows_matrix_sum 10 10

Sequential Time = 7.15256e-07
Sequential Sum Vector:
421 499 575 669 561 374 417 568 540 524

Parallel Time = 1.40667e-05
Parallel Sum Vector:
421 499 575 669 561 374 417 568 540 524
```


### **Also added cmake_minimum_required to cmake script**

**This is necessary so that warnings do not appear when building from their own directory.
(No effect, but annoying)**

```
CMake Warning (dev) in CMakeLists.txt:
  No cmake_minimum_required command is present.  A line of code such as

    cmake_minimum_required(VERSION 3.10)

  should be added at the top of the file.  The version specified may be lower
  if you wish to support older CMake versions for this project.  For more
  information run "cmake --help-policy CMP0000".
This warning is for project developers.  Use -Wno-dev to suppress it.
```